### PR TITLE
Fix tmux helper symlink path and list dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This Repository Dotfiles contain my personal config files. Here you'll find conf
 ## Prerequisites
 
 1. git
+2. [oh-my-zsh](https://ohmyz.sh/)
+3. tmux
+4. neovim
+5. fzf *(optional for the `t` helper)*
 
 ## usage & installation
 

--- a/install
+++ b/install
@@ -11,7 +11,7 @@ ln -Fsv $DOTFILES/scripts/copyright $HOME/.local/bin/copyright
 # tmux
 ln -Fsv $DOTFILES/tmux/tmux.conf $HOME/.tmux.conf
 
-ln -Fsv $DOTFILES/.scripts/t $HOME/.local/bin/t
+ln -Fsv $DOTFILES/scripts/t $HOME/.local/bin/t
 
 ln -Fsv $DOTFILES/nvim $HOME/.config/nvim
 


### PR DESCRIPTION
## Summary
- fix symlink path for tmux helper in `install`
- document required tools in `README`

## Testing
- `shellcheck install scripts/t`

------
https://chatgpt.com/codex/tasks/task_e_686be9e7e3e0832db4f554fe2fed5c6f