### PR TITLE
Improve install script and tmux helper

### DIFF
--- a/install
+++ b/install
@@ -1,36 +1,66 @@
 #!/bin/bash
 
-DOTFILES=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+set -e
 
-ln -Fsv $DOTFILES/.zshrc $HOME/.zshrc
+DRY_RUN=false
+VERBOSE=false
 
-# link copyright script
-mkdir -p $HOME/.local/bin
-ln -Fsv $DOTFILES/scripts/copyright $HOME/.local/bin/copyright
+usage() {
+    echo "Usage: $0 [-n] [-v]" >&2
+    echo "  -n  dry run, show actions without executing" >&2
+    echo "  -v  verbose output" >&2
+}
 
-# tmux
-ln -Fsv $DOTFILES/tmux/tmux.conf $HOME/.tmux.conf
+while getopts ":nv" opt; do
+    case "$opt" in
+        n) DRY_RUN=true ;;
+        v) VERBOSE=true ;;
+        *) usage; exit 1 ;;
+    esac
+done
+shift $((OPTIND-1))
 
-ln -Fsv $DOTFILES/scripts/t $HOME/.local/bin/t
+OS=$(uname)
+DOTFILES=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-ln -Fsv $DOTFILES/nvim $HOME/.config/nvim
+log() {
+    [ "$VERBOSE" = true ] && echo "$@"
+}
 
-# add warp themes
-ln -Fsv $DOTFILES/warp $HOME/.warp
+link_file() {
+    local src="$1" dest="$2"
 
-# set up nvim
-ln -Fsv "${HOME}/bin/nvim" "${HOME}/.config/nvim"
+    if [ ! -e "$src" ]; then
+        echo "Error: source '$src' does not exist" >&2
+        exit 1
+    fi
 
-# set up ghostty config
-ln -Fsv "${HOME}/bin/ghostty" "${HOME}/Library/Application Support/com.mitchellh.ghostty"
+    log "ln -sf $src $dest"
+    if [ "$DRY_RUN" = false ]; then
+        ln -sf "$src" "$dest" || { echo "Failed to link $src -> $dest" >&2; exit 1; }
+    fi
+}
 
-# set up yabai & skhd
-ln -Fsv "${HOME}/bin/yabai" "${HOME}/.config/yabai"
-ln -Fsv "${HOME}/bin/skhd" "${HOME}/.config/skhd"
+# common directories
+mkdir -p "$HOME/.local/bin" "$HOME/.config" "$HOME/Library/Application Support" 2>/dev/null || true
 
-# link gitignore global
-ln -Fsv "${HOME}/bin/.gitignore" "${HOME}/.gitignore"
-git config --global core.excludesfile ~/.gitignore
+link_file "$DOTFILES/.zshrc" "$HOME/.zshrc"
+link_file "$DOTFILES/scripts/copyright" "$HOME/.local/bin/copyright"
+link_file "$DOTFILES/tmux/tmux.conf" "$HOME/.tmux.conf"
+link_file "$DOTFILES/scripts/t" "$HOME/.local/bin/t"
+link_file "$DOTFILES/nvim" "$HOME/.config/nvim"
+link_file "$DOTFILES/warp" "$HOME/.warp"
 
-# link aerospace config
-ln -Fsv "${HOME}/bin/aerospace.toml" "${HOME}/.aerospace.toml"
+# set up nvim config from local repo
+link_file "${HOME}/bin/nvim" "${HOME}/.config/nvim"
+
+if [[ "$OS" == "Darwin" ]]; then
+    link_file "${HOME}/bin/ghostty" "${HOME}/Library/Application Support/com.mitchellh.ghostty"
+    link_file "${HOME}/bin/yabai" "${HOME}/.config/yabai"
+    link_file "${HOME}/bin/skhd" "${HOME}/.config/skhd"
+fi
+
+link_file "${HOME}/bin/.gitignore" "${HOME}/.gitignore"
+git config --global core.excludesfile "$HOME/.gitignore"
+
+link_file "${HOME}/bin/aerospace.toml" "${HOME}/.aerospace.toml"

--- a/scripts/t
+++ b/scripts/t
@@ -1,19 +1,38 @@
 #!/bin/bash
 
+# Helper to create or attach to tmux sessions for project directories.
+# If no directory is provided, fzf is used to select one from common locations.
+
+set -e
+
+usage() {
+    echo "Usage: $0 [DIRECTORY]" >&2
+    exit 1
+}
+
+# Determine the directory to open
+if [[ $# -gt 1 ]]; then
+    usage
+fi
+
 if [[ $# -eq 1 ]]; then
-	selected=$1
+    project_dir=$1
 else
     items=$(find ~/Code/Herd -maxdepth 1 -mindepth 1 -type d ! -name ".flux")
     items=$(echo -e "$items\n$(find ~/bin -maxdepth 0)")
-    # items=$(echo -e "$items\n$(find ~/Tmp -maxdepth 1 -mindepth 1 -type d)")
-    selected=$(echo -e "$items" | fzf)
+    project_dir=$(echo -e "$items" | fzf)
 fi
 
-dirname=$(basename $selected | sed 's/\./_/g')
-
-if tmux has-session -t "$dirname" 2>/dev/null; then
-    tmux switch-client -t "$dirname"
-    exit 0
+if [[ -z "$project_dir" || ! -d "$project_dir" ]]; then
+    echo "No valid directory selected" >&2
+    usage
 fi
 
-tmux new-session -c $selected -d -s $dirname && tmux switch-client -t $dirname || tmux new -c $selected -A -s $dirname
+session_name=$(basename "$project_dir" | sed 's/\./_/g')
+
+if [[ -n "$TMUX" ]]; then
+    tmux new-session -A -d -s "$session_name" -c "$project_dir"
+    tmux switch-client -t "$session_name"
+else
+    tmux new-session -A -s "$session_name" -c "$project_dir"
+fi


### PR DESCRIPTION
## Summary
- add dry-run, verbose and error handling to install script
- add macOS checks for mac-only links
- improve `scripts/t` helper with usage info and better tmux attach logic

## Testing
- `shellcheck install scripts/t`
- `bash -n install`
- `bash -n scripts/t`
- `apt-get update`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_686beff900a4832d88daadbbd016d160